### PR TITLE
Azure does not support some Scoping Element

### DIFF
--- a/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
+++ b/lib/SimpleSAML/Metadata/MetaDataStorageHandlerFlatFile.php
@@ -113,7 +113,7 @@ class SimpleSAML_Metadata_MetaDataStorageHandlerFlatFile extends SimpleSAML_Meta
         foreach ($metadataSet as $entityId => &$entry) {
             if (preg_match('/__DYNAMIC(:[0-9]+)?__/', $entityId)) {
                 $entry['entityid'] = $this->generateDynamicHostedEntityID($set);
-            } else {
+            } else if (!array_key_exists('entityid', $entry) || !empty($entry['entityid'])) {
                 $entry['entityid'] = $entityId;
             }
         }


### PR DESCRIPTION
https://msdn.microsoft.com/fr-fr/library/azure/dn195589.aspx

The Scoping element, which includes a list of identity providers, is optional in AuthnRequest elements sent to Azure Active Directory.

Do not include the ProxyCount attribute, IDPList option, or the RequesterID element, in the Scoping element of an AuthnRequest sent to Azure Active Directory. They are not supported.